### PR TITLE
CV-18839 : RTSP Server video stream artifacting - buffer overflow errors

### DIFF
--- a/Proj/LiveH264VideoDeviceSource.cpp
+++ b/Proj/LiveH264VideoDeviceSource.cpp
@@ -52,7 +52,7 @@ CreateNew(UsageEnvironment& env, unsigned clientId,
 	// When constructing a 'simple' LiveDeviceSource we'll just create a simple frame grabber
 	auto videoDeviceSource = new LiveH264VideoDeviceSource(env, clientId, parentSubsession,
 		sps, pps, frameGrabber, rateAdaptationFactory, globalRateControl);
-	OutPacketBuffer::increaseMaxSizeTo(300000); // bytes
+	OutPacketBuffer::increaseMaxSizeTo(700000); // bytes
 	return videoDeviceSource;
 }
 

--- a/Proj/LiveH265VideoDeviceSource.cpp
+++ b/Proj/LiveH265VideoDeviceSource.cpp
@@ -52,7 +52,7 @@ CreateNew(UsageEnvironment& env, unsigned clientId,
 	// When constructing a 'simple' LiveDeviceSource we'll just create a simple frame grabber
 	auto videoDeviceSource = new LiveH265VideoDeviceSource(env, clientId, parentSubsession,
 		vps, sps, pps, frameGrabber, rateAdaptationFactory, globalRateControl);
-	OutPacketBuffer::increaseMaxSizeTo(300000); // bytes
+	OutPacketBuffer::increaseMaxSizeTo(700000); // bytes
 	return videoDeviceSource;
 }
 

--- a/Proj/LiveMPEGVideoDeviceSource.cpp
+++ b/Proj/LiveMPEGVideoDeviceSource.cpp
@@ -55,7 +55,7 @@ CreateNew(UsageEnvironment& env, unsigned clientId,
 	// When constructing a 'simple' LiveDeviceSource we'll just create a simple frame grabber
 	auto videoDeviceSource = new LiveMPEGVideoDeviceSource(env, clientId, parentSubsession,
 		frameGrabber, rateAdaptationFactory, globalRateControl);
-	OutPacketBuffer::increaseMaxSizeTo(300000); // bytes
+	OutPacketBuffer::increaseMaxSizeTo(700000); // bytes
 	return videoDeviceSource;
 }
 


### PR DESCRIPTION
CV-18839
- Increase OutPacketBuffer::MaxSize to 700K from 300K using OutPacketBuffer::increaseMaxSizeTo(700000) to avoid buffer overflow errors